### PR TITLE
Subjects, predicates, objects, and substantiations

### DIFF
--- a/claimont.jsonld
+++ b/claimont.jsonld
@@ -1,113 +1,56 @@
 [
   {
-    "@id": "http://w3id.org/claimont",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Ontology"
-    ],
-    "http://purl.org/dc/terms/description": [
-      {
-        "@language": "en",
-        "@value": "An ontology for describing claims and their substantiation."
-      }
-    ],
-    "http://purl.org/dc/terms/title": [
-      {
-        "@language": "en",
-        "@value": "Claim Ontology"
-      }
-    ]
-  },
-  {
-    "@id": "http://w3id.org/claimont#Report",
+    "@id": "http://w3id.org/claimont#Predicate",
     "@type": [
       "http://www.w3.org/2002/07/owl#Class"
     ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
+    "http://www.w3.org/2000/01/rdf-schema#comment": [
       {
-        "@value": "Report"
+        "@value": "Deprecated. Use owl:Thing instead."
       }
     ],
-    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
+    "http://www.w3.org/2000/01/rdf-schema#label": [
       {
-        "@id": "http://w3id.org/claimont#Claim"
+        "@value": "Predicate"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#deprecated": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+        "@value": true
       }
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
       {
-        "@value": "A claim made according to some specification."
+        "@value": "The characteristic, attribute, or relationship asserted about the subject of a claim or an attestation."
       }
     ]
   },
   {
-    "@id": "http://w3id.org/claimont#comprisesClaims",
+    "@id": "http://w3id.org/claimont#hasPropertyPredicate",
     "@type": [
       "http://www.w3.org/2002/07/owl#ObjectProperty"
     ],
-    "http://www.w3.org/2000/01/rdf-schema#domain": [
+    "http://www.w3.org/2000/01/rdf-schema#comment": [
       {
-        "@id": "http://w3id.org/claimont#Claim"
+        "@language": "en",
+        "@value": "\n\t\t\tRelates a claim or attestation to the RDF, RDFS, OWL object property, or OWL data property that represents the predicate of the claim.\n\t\t"
       }
     ],
     "http://www.w3.org/2000/01/rdf-schema#label": [
       {
-        "@value": "comprisesClaims"
+        "@language": "en",
+        "@value": "hasPropertyPredicate"
       }
     ],
     "http://www.w3.org/2000/01/rdf-schema#range": [
       {
-        "@id": "http://w3id.org/claimont#Claim"
-      }
-    ]
-  },
-  {
-    "@id": "http://w3id.org/claimont#hasObject",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#ObjectProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#domain": [
-      {
-        "@id": "http://w3id.org/claimont#Claim"
+        "@id": "http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"
       }
     ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
+    "http://www.w3.org/2000/01/rdf-schema#subPropertyOf": [
       {
-        "@value": "hasObject"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#range": [
-      {
-        "@id": "http://w3id.org/claimont#Object"
-      }
-    ]
-  },
-  {
-    "@id": "http://w3id.org/claimont#supports",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#ObjectProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#domain": [
-      {
-        "@id": "http://w3id.org/claimont#Substantiation"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "supports"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#range": [
-      {
-        "@id": "http://w3id.org/claimont#Claim"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#inverseOf": [
-      {
-        "@id": "http://w3id.org/claimont#isSupportedBy"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@value": "Indicates that a substantiation provides evidence or backing for a particular claim."
+        "@id": "http://w3id.org/claimont#hasPredicate"
       }
     ]
   },
@@ -128,110 +71,85 @@
     ]
   },
   {
-    "@id": "http://w3id.org/claimont#Subject",
+    "@id": "http://w3id.org/claimont#Claimant",
     "@type": [
       "http://www.w3.org/2002/07/owl#Class"
     ],
     "http://www.w3.org/2000/01/rdf-schema#label": [
       {
-        "@value": "Subject"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#equivalentClass": [
-      {
-        "@id": "http://www.w3.org/2002/07/owl#Thing"
+        "@value": "Claimant"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
       {
-        "@value": "The thing about which a statement (i.e., a claim or an attestation) is made."
+        "@value": "An entity (e.g., a person, an organisation or a system) that makes a claim."
       }
     ]
   },
   {
-    "@id": "http://w3id.org/claimont#Substantiation",
+    "@id": "http://w3id.org/claimont#Attestation",
     "@type": [
       "http://www.w3.org/2002/07/owl#Class"
     ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
+    "http://www.w3.org/2000/01/rdf-schema#comment": [
       {
-        "@value": "Substantiation"
+        "@value": "A verifier's statement is an example of an attestation."
       }
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@value": "A thing presented in support of the truthfulness of a claim."
-      }
-    ]
-  },
-  {
-    "@id": "http://w3id.org/claimont#IdentityClaim",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
     ],
     "http://www.w3.org/2000/01/rdf-schema#label": [
       {
-        "@value": "Identity Claim"
+        "@value": "Attestation"
       }
     ],
     "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
       {
+        "@id": "http://w3id.org/claimont#Substantiation"
+      },
+      {
+        "@id": "http://docs.oasis-open.org/legalruleml/ns/v1.0/Statement"
+      },
+      {
+        "@id": "_:N79ffb11a02e646b8be80853d3be36a52"
+      },
+      {
+        "@id": "_:N5adb6f9b455c4b58ac736dfb2454abbb"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@value": "An indefeasible statement, usually formal, made by an entity according to which they have witnessed or been presented with sufficient evidence to consider a specific claim made by another entity as truthful or accurate."
+      }
+    ]
+  },
+  {
+    "@id": "_:N79ffb11a02e646b8be80853d3be36a52",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
         "@id": "http://w3id.org/claimont#Claim"
       }
     ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
+    "http://www.w3.org/2002/07/owl#onProperty": [
       {
-        "@value": "A statement made by a claimant about their identity, usually with reference to some identification system."
+        "@id": "http://w3id.org/claimont#hasSubject"
       }
     ]
   },
   {
-    "@id": "http://w3id.org/claimont#Predicate",
+    "@id": "_:N5adb6f9b455c4b58ac736dfb2454abbb",
     "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
+      "http://www.w3.org/2002/07/owl#Restriction"
     ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
       {
-        "@value": "Predicate"
+        "@id": "http://w3id.org/claimont#Attester"
       }
     ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
+    "http://www.w3.org/2002/07/owl#onProperty": [
       {
-        "@value": "The characteristic, attribute, or relationship asserted about the subject of a claim or an attestation."
-      }
-    ]
-  },
-  {
-    "@id": "_:Nba57177a9f344bb5ab4addc9d6a91964",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#AllDisjointClasses"
-    ],
-    "http://www.w3.org/2002/07/owl#members": [
-      {
-        "@list": [
-          {
-            "@id": "http://w3id.org/claimont#Claim"
-          },
-          {
-            "@id": "http://w3id.org/claimont#Substantiation"
-          }
-        ]
-      }
-    ]
-  },
-  {
-    "@id": "http://w3id.org/claimont#Object",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "Object"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@value": "The target or value associated with the predicate of a claim or an attestation."
+        "@id": "http://w3id.org/claimont#isMadeBy"
       }
     ]
   },
@@ -267,39 +185,144 @@
     ]
   },
   {
-    "@id": "http://w3id.org/claimont#hasSubject",
+    "@id": "http://w3id.org/claimont#Object",
     "@type": [
-      "http://www.w3.org/2002/07/owl#ObjectProperty"
+      "http://www.w3.org/2002/07/owl#Class"
     ],
     "http://www.w3.org/2000/01/rdf-schema#comment": [
       {
-        "@value": "This property is used on the Claim and Attestation classes. For a Claim the value assigned to this property must be a Subject; for an Attestation the value must be a Claim. This is enforced by owl:Restriction (see the definitions of the Claim and Attestation classes.)"
+        "@value": "Deprecated. Use owl:Thing instead."
       }
     ],
     "http://www.w3.org/2000/01/rdf-schema#label": [
       {
-        "@value": "hasSubject"
+        "@value": "Object"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#deprecated": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+        "@value": true
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@value": "The target or value associated with the predicate of a claim or an attestation."
+      }
+    ]
+  },
+  {
+    "@id": "http://w3id.org/claimont#IdentityClaim",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "Identity Claim"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
+      {
+        "@id": "http://w3id.org/claimont#Claim"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@value": "A statement made by a claimant about their identity, usually with reference to some identification system."
+      }
+    ]
+  },
+  {
+    "@id": "http://w3id.org/claimont#Report",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "Report"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
+      {
+        "@id": "http://w3id.org/claimont#Claim"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@value": "A claim made according to some specification."
+      }
+    ]
+  },
+  {
+    "@id": "http://w3id.org/claimont#hasTextPredicate",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#DatatypeProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#comment": [
+      {
+        "@language": "en",
+        "@value": "\n\t\t\tRelates a claim or attestation to its predicate through a simple text string.\n\t\t"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@language": "en",
+        "@value": "hasTextPredicate"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#range": [
+      {
+        "@id": "http://www.w3.org/2001/XMLSchema#string"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#subPropertyOf": [
+      {
+        "@id": "http://w3id.org/claimont#hasPredicate"
       }
     ]
   },
   {
     "@id": "http://w3id.org/claimont#hasPredicate",
     "@type": [
-      "http://www.w3.org/2002/07/owl#ObjectProperty"
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#comment": [
+      {
+        "@language": "en",
+        "@value": "Generic property that relates a claim or attestation to its predicate."
+      },
+      {
+        "@language": "en",
+        "@value": "Do not use this property directly - use its 'hasTextPredicate' or 'hasPropertyPredicate' subproperties instead."
+      }
     ],
     "http://www.w3.org/2000/01/rdf-schema#domain": [
       {
-        "@id": "http://w3id.org/claimont#Claim"
+        "@id": "_:N0a192c29a0e7405ea3570f00bc2ddd90"
       }
     ],
     "http://www.w3.org/2000/01/rdf-schema#label": [
       {
+        "@language": "en",
         "@value": "hasPredicate"
       }
+    ]
+  },
+  {
+    "@id": "_:N0a192c29a0e7405ea3570f00bc2ddd90",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
     ],
-    "http://www.w3.org/2000/01/rdf-schema#range": [
+    "http://www.w3.org/2002/07/owl#unionOf": [
       {
-        "@id": "http://w3id.org/claimont#Predicate"
+        "@list": [
+          {
+            "@id": "http://w3id.org/claimont#Claim"
+          },
+          {
+            "@id": "http://w3id.org/claimont#Attestation"
+          }
+        ]
       }
     ]
   },
@@ -320,85 +343,157 @@
     ]
   },
   {
-    "@id": "http://w3id.org/claimont#Attestation",
+    "@id": "http://w3id.org/claimont#hasObject",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#ObjectProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#domain": [
+      {
+        "@id": "http://w3id.org/claimont#Claim"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "hasObject"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#range": [
+      {
+        "@id": "http://www.w3.org/2002/07/owl#Thing"
+      }
+    ]
+  },
+  {
+    "@id": "http://w3id.org/claimont#hasSubject",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#ObjectProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#comment": [
+      {
+        "@value": "This property is used on the Claim and Attestation classes. For a Claim the value assigned to this property must be a Subject; for an Attestation the value must be a Claim. This is enforced by owl:Restriction (see the definitions of the Claim and Attestation classes.)"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "hasSubject"
+      }
+    ]
+  },
+  {
+    "@id": "http://w3id.org/claimont#Substantiation",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "Substantiation"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@value": "A thing presented in support of the truthfulness of a claim."
+      }
+    ]
+  },
+  {
+    "@id": "http://w3id.org/claimont#Subject",
     "@type": [
       "http://www.w3.org/2002/07/owl#Class"
     ],
     "http://www.w3.org/2000/01/rdf-schema#comment": [
       {
-        "@value": "A verifier's statement is an example of an attestation."
+        "@value": "Deprecated. Use owl:Thing instead."
       }
     ],
     "http://www.w3.org/2000/01/rdf-schema#label": [
       {
-        "@value": "Attestation"
+        "@value": "Subject"
       }
     ],
-    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
+    "http://www.w3.org/2002/07/owl#deprecated": [
       {
-        "@id": "http://w3id.org/claimont#Substantiation"
-      },
+        "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+        "@value": true
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#equivalentClass": [
       {
-        "@id": "http://docs.oasis-open.org/legalruleml/ns/v1.0/Statement"
-      },
-      {
-        "@id": "_:N92e11dab7b774d0a980a391b6452fa13"
-      },
-      {
-        "@id": "_:N4038b6288b6a4835b2303ee971c12e6c"
+        "@id": "http://www.w3.org/2002/07/owl#Thing"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
       {
-        "@value": "An indefeasible statement, usually formal, made by an entity according to which they have witnessed or been presented with sufficient evidence to consider a specific claim made by another entity as truthful or accurate."
+        "@value": "The thing about which a statement (i.e., a claim or an attestation) is made."
       }
     ]
   },
   {
-    "@id": "_:N92e11dab7b774d0a980a391b6452fa13",
+    "@id": "http://w3id.org/claimont",
     "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
+      "http://www.w3.org/2002/07/owl#Ontology"
     ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+    "http://purl.org/dc/terms/description": [
+      {
+        "@language": "en",
+        "@value": "An ontology for describing claims and their substantiation."
+      }
+    ],
+    "http://purl.org/dc/terms/title": [
+      {
+        "@language": "en",
+        "@value": "Claim Ontology"
+      }
+    ]
+  },
+  {
+    "@id": "http://w3id.org/claimont#supports",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#ObjectProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#domain": [
+      {
+        "@id": "http://w3id.org/claimont#Substantiation"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "supports"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#range": [
       {
         "@id": "http://w3id.org/claimont#Claim"
       }
     ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
+    "http://www.w3.org/2002/07/owl#inverseOf": [
       {
-        "@id": "http://w3id.org/claimont#hasSubject"
-      }
-    ]
-  },
-  {
-    "@id": "_:N4038b6288b6a4835b2303ee971c12e6c",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "http://w3id.org/claimont#Attester"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "http://w3id.org/claimont#isMadeBy"
-      }
-    ]
-  },
-  {
-    "@id": "http://w3id.org/claimont#Claimant",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "Claimant"
+        "@id": "http://w3id.org/claimont#isSupportedBy"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
       {
-        "@value": "An entity (e.g., a person, an organisation or a system) that makes a claim."
+        "@value": "Indicates that a substantiation provides evidence or backing for a particular claim."
+      }
+    ]
+  },
+  {
+    "@id": "http://w3id.org/claimont#comprisesClaims",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#ObjectProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#domain": [
+      {
+        "@id": "http://w3id.org/claimont#Claim"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "comprisesClaims"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#range": [
+      {
+        "@id": "http://w3id.org/claimont#Claim"
       }
     ]
   },
@@ -422,10 +517,10 @@
         "@id": "http://docs.oasis-open.org/legalruleml/ns/v1.0/Statement"
       },
       {
-        "@id": "_:N682ae438cb3a4dc39c6a208673ca5eef"
+        "@id": "_:N1fa4dfc670a54721af50ac70160b6290"
       },
       {
-        "@id": "_:N0d1b51f21ea845668051a158f0dfe6fb"
+        "@id": "_:N06ff9ed8322a4aabb1f1b769c4074c08"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
@@ -435,13 +530,13 @@
     ]
   },
   {
-    "@id": "_:N682ae438cb3a4dc39c6a208673ca5eef",
+    "@id": "_:N1fa4dfc670a54721af50ac70160b6290",
     "@type": [
       "http://www.w3.org/2002/07/owl#Restriction"
     ],
     "http://www.w3.org/2002/07/owl#allValuesFrom": [
       {
-        "@id": "http://w3id.org/claimont#Subject"
+        "@id": "http://www.w3.org/2002/07/owl#Thing"
       }
     ],
     "http://www.w3.org/2002/07/owl#onProperty": [
@@ -451,7 +546,7 @@
     ]
   },
   {
-    "@id": "_:N0d1b51f21ea845668051a158f0dfe6fb",
+    "@id": "_:N06ff9ed8322a4aabb1f1b769c4074c08",
     "@type": [
       "http://www.w3.org/2002/07/owl#Restriction"
     ],
@@ -463,6 +558,24 @@
     "http://www.w3.org/2002/07/owl#onProperty": [
       {
         "@id": "http://w3id.org/claimont#isMadeBy"
+      }
+    ]
+  },
+  {
+    "@id": "_:Nbf93ee58f3a94a90aca282b1a92fa599",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#AllDisjointClasses"
+    ],
+    "http://www.w3.org/2002/07/owl#members": [
+      {
+        "@list": [
+          {
+            "@id": "http://w3id.org/claimont#Claim"
+          },
+          {
+            "@id": "http://w3id.org/claimont#Substantiation"
+          }
+        ]
       }
     ]
   }

--- a/claimont.jsonld
+++ b/claimont.jsonld
@@ -1,5 +1,191 @@
 [
   {
+    "@id": "http://w3id.org/claimont#Attester",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "Attester"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@value": "An entity (e.g., a person, an organisation or a system) that makes an attestation."
+      }
+    ]
+  },
+  {
+    "@id": "http://w3id.org/claimont#hasSubject",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#ObjectProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#comment": [
+      {
+        "@value": "This property is used on the Claim and Attestation classes. For a Claim the value assigned to this property must be a Subject; for an Attestation the value must be a Claim. This is enforced by owl:Restriction (see the definitions of the Claim and Attestation classes.)"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "hasSubject"
+      }
+    ]
+  },
+  {
+    "@id": "http://w3id.org/claimont#Attestation",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#comment": [
+      {
+        "@value": "A verifier's statement is an example of an attestation."
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "Attestation"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
+      {
+        "@id": "http://docs.oasis-open.org/legalruleml/ns/v1.0/Statement"
+      },
+      {
+        "@id": "_:N73e7e34b3ae044dda46259c0eb63893a"
+      },
+      {
+        "@id": "_:Ncd8cc7e764c547318c7b2f7411cb4b4f"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@value": "An indefeasible statement, usually formal, made by an entity according to which they have witnessed or been presented with sufficient evidence to consider a specific claim made by another entity as truthful or accurate."
+      }
+    ]
+  },
+  {
+    "@id": "_:N73e7e34b3ae044dda46259c0eb63893a",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "http://w3id.org/claimont#Claim"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "http://w3id.org/claimont#hasSubject"
+      }
+    ]
+  },
+  {
+    "@id": "_:Ncd8cc7e764c547318c7b2f7411cb4b4f",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "http://w3id.org/claimont#Attester"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "http://w3id.org/claimont#isMadeBy"
+      }
+    ]
+  },
+  {
+    "@id": "http://w3id.org/claimont#isMadeBy",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#ObjectProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#comment": [
+      {
+        "@value": "This property is used on the Claim and Attestation classes. For a Claim the value assigned to this property must be a Claimant; for an Attestation the value must be an Attester. This is enforced by owl:Restriction (see the definitions of the Claim and Attestation classes.)"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "isMadeBy"
+      }
+    ]
+  },
+  {
+    "@id": "http://w3id.org/claimont#Claimant",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "Claimant"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@value": "An entity (e.g., a person, an organisation or a system) that makes a claim."
+      }
+    ]
+  },
+  {
+    "@id": "http://w3id.org/claimont#Object",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#comment": [
+      {
+        "@value": "Deprecated. Use owl:Thing instead."
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "Object"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#deprecated": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+        "@value": true
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@value": "The target or value associated with the predicate of a claim or an attestation."
+      }
+    ]
+  },
+  {
+    "@id": "http://w3id.org/claimont#supports",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#ObjectProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#domain": [
+      {
+        "@id": "http://www.w3.org/2000/01/rdf-schema#Resource"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "supports"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#range": [
+      {
+        "@id": "http://w3id.org/claimont#Claim"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#inverseOf": [
+      {
+        "@id": "http://w3id.org/claimont#isSupportedBy"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@value": "Indicates that the resource in question serves as evidence or backing for the claim in question."
+      }
+    ]
+  },
+  {
     "@id": "http://w3id.org/claimont#Predicate",
     "@type": [
       "http://www.w3.org/2002/07/owl#Class"
@@ -23,6 +209,139 @@
     "http://www.w3.org/2004/02/skos/core#definition": [
       {
         "@value": "The characteristic, attribute, or relationship asserted about the subject of a claim or an attestation."
+      }
+    ]
+  },
+  {
+    "@id": "http://w3id.org/claimont#Substantiation",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#comment": [
+      {
+        "@value": "Deprecated."
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "Substantiation"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#deprecated": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+        "@value": true
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@value": "A thing presented in support of the truthfulness of a claim."
+      }
+    ]
+  },
+  {
+    "@id": "http://w3id.org/claimont#hasObject",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#ObjectProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#domain": [
+      {
+        "@id": "http://w3id.org/claimont#Claim"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "hasObject"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#range": [
+      {
+        "@id": "http://www.w3.org/2002/07/owl#Thing"
+      }
+    ]
+  },
+  {
+    "@id": "http://w3id.org/claimont#Claim",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#comment": [
+      {
+        "@value": "A Claim may comprise other Claims."
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "Claim"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
+      {
+        "@id": "http://docs.oasis-open.org/legalruleml/ns/v1.0/Statement"
+      },
+      {
+        "@id": "_:N26f1cf67294a401dbb7e0579b4859779"
+      },
+      {
+        "@id": "_:N09756a3d8dd5498fa62845a4c8f4b2a1"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@value": "A defeasible statement about a thing."
+      }
+    ]
+  },
+  {
+    "@id": "_:N26f1cf67294a401dbb7e0579b4859779",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "http://www.w3.org/2002/07/owl#Thing"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "http://w3id.org/claimont#hasSubject"
+      }
+    ]
+  },
+  {
+    "@id": "_:N09756a3d8dd5498fa62845a4c8f4b2a1",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "http://w3id.org/claimont#Claimant"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "http://w3id.org/claimont#isMadeBy"
+      }
+    ]
+  },
+  {
+    "@id": "http://w3id.org/claimont#Report",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "Report"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
+      {
+        "@id": "http://w3id.org/claimont#Claim"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@value": "A claim made according to some specification."
       }
     ]
   },
@@ -55,137 +374,25 @@
     ]
   },
   {
-    "@id": "http://w3id.org/claimont#Attester",
+    "@id": "http://w3id.org/claimont",
     "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
+      "http://www.w3.org/2002/07/owl#Ontology"
     ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
+    "http://purl.org/dc/terms/description": [
       {
-        "@value": "Attester"
+        "@language": "en",
+        "@value": "An ontology for describing claims and their substantiation."
       }
     ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
+    "http://purl.org/dc/terms/title": [
       {
-        "@value": "An entity (e.g., a person, an organisation or a system) that makes an attestation."
+        "@language": "en",
+        "@value": "Claim Ontology"
       }
     ]
   },
   {
-    "@id": "http://w3id.org/claimont#Claimant",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "Claimant"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@value": "An entity (e.g., a person, an organisation or a system) that makes a claim."
-      }
-    ]
-  },
-  {
-    "@id": "http://w3id.org/claimont#Attestation",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#comment": [
-      {
-        "@value": "A verifier's statement is an example of an attestation."
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "Attestation"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
-      {
-        "@id": "http://w3id.org/claimont#Substantiation"
-      },
-      {
-        "@id": "http://docs.oasis-open.org/legalruleml/ns/v1.0/Statement"
-      },
-      {
-        "@id": "_:N79ffb11a02e646b8be80853d3be36a52"
-      },
-      {
-        "@id": "_:N5adb6f9b455c4b58ac736dfb2454abbb"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@value": "An indefeasible statement, usually formal, made by an entity according to which they have witnessed or been presented with sufficient evidence to consider a specific claim made by another entity as truthful or accurate."
-      }
-    ]
-  },
-  {
-    "@id": "_:N79ffb11a02e646b8be80853d3be36a52",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "http://w3id.org/claimont#Claim"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "http://w3id.org/claimont#hasSubject"
-      }
-    ]
-  },
-  {
-    "@id": "_:N5adb6f9b455c4b58ac736dfb2454abbb",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "http://w3id.org/claimont#Attester"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "http://w3id.org/claimont#isMadeBy"
-      }
-    ]
-  },
-  {
-    "@id": "http://w3id.org/claimont#isSupportedBy",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#ObjectProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#domain": [
-      {
-        "@id": "http://w3id.org/claimont#Claim"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "isSupportedBy"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#range": [
-      {
-        "@id": "http://w3id.org/claimont#Substantiation"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#inverseOf": [
-      {
-        "@id": "http://w3id.org/claimont#supports"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@value": "Indicates that a claim is backed or reinforced by some form of substantiation or evidence."
-      }
-    ]
-  },
-  {
-    "@id": "http://w3id.org/claimont#Object",
+    "@id": "http://w3id.org/claimont#Subject",
     "@type": [
       "http://www.w3.org/2002/07/owl#Class"
     ],
@@ -196,7 +403,7 @@
     ],
     "http://www.w3.org/2000/01/rdf-schema#label": [
       {
-        "@value": "Object"
+        "@value": "Subject"
       }
     ],
     "http://www.w3.org/2002/07/owl#deprecated": [
@@ -205,9 +412,14 @@
         "@value": true
       }
     ],
+    "http://www.w3.org/2002/07/owl#equivalentClass": [
+      {
+        "@id": "http://www.w3.org/2002/07/owl#Thing"
+      }
+    ],
     "http://www.w3.org/2004/02/skos/core#definition": [
       {
-        "@value": "The target or value associated with the predicate of a claim or an attestation."
+        "@value": "The thing about which a statement (i.e., a claim or an attestation) is made."
       }
     ]
   },
@@ -233,23 +445,23 @@
     ]
   },
   {
-    "@id": "http://w3id.org/claimont#Report",
+    "@id": "http://w3id.org/claimont#comprisesClaims",
     "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
+      "http://www.w3.org/2002/07/owl#ObjectProperty"
     ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "Report"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
+    "http://www.w3.org/2000/01/rdf-schema#domain": [
       {
         "@id": "http://w3id.org/claimont#Claim"
       }
     ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
+    "http://www.w3.org/2000/01/rdf-schema#label": [
       {
-        "@value": "A claim made according to some specification."
+        "@value": "comprisesClaims"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#range": [
+      {
+        "@id": "http://w3id.org/claimont#Claim"
       }
     ]
   },
@@ -298,7 +510,7 @@
     ],
     "http://www.w3.org/2000/01/rdf-schema#domain": [
       {
-        "@id": "_:N0a192c29a0e7405ea3570f00bc2ddd90"
+        "@id": "_:N63bfdf57e9be4bfd98a5893aedc244cf"
       }
     ],
     "http://www.w3.org/2000/01/rdf-schema#label": [
@@ -309,7 +521,7 @@
     ]
   },
   {
-    "@id": "_:N0a192c29a0e7405ea3570f00bc2ddd90",
+    "@id": "_:N63bfdf57e9be4bfd98a5893aedc244cf",
     "@type": [
       "http://www.w3.org/2002/07/owl#Class"
     ],
@@ -327,23 +539,7 @@
     ]
   },
   {
-    "@id": "http://w3id.org/claimont#isMadeBy",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#ObjectProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#comment": [
-      {
-        "@value": "This property is used on the Claim and Attestation classes. For a Claim the value assigned to this property must be a Claimant; for an Attestation the value must be an Attester. This is enforced by owl:Restriction (see the definitions of the Claim and Attestation classes.)"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "isMadeBy"
-      }
-    ]
-  },
-  {
-    "@id": "http://w3id.org/claimont#hasObject",
+    "@id": "http://w3id.org/claimont#isSupportedBy",
     "@type": [
       "http://www.w3.org/2002/07/owl#ObjectProperty"
     ],
@@ -354,228 +550,22 @@
     ],
     "http://www.w3.org/2000/01/rdf-schema#label": [
       {
-        "@value": "hasObject"
+        "@value": "isSupportedBy"
       }
     ],
     "http://www.w3.org/2000/01/rdf-schema#range": [
       {
-        "@id": "http://www.w3.org/2002/07/owl#Thing"
-      }
-    ]
-  },
-  {
-    "@id": "http://w3id.org/claimont#hasSubject",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#ObjectProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#comment": [
-      {
-        "@value": "This property is used on the Claim and Attestation classes. For a Claim the value assigned to this property must be a Subject; for an Attestation the value must be a Claim. This is enforced by owl:Restriction (see the definitions of the Claim and Attestation classes.)"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "hasSubject"
-      }
-    ]
-  },
-  {
-    "@id": "http://w3id.org/claimont#Substantiation",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "Substantiation"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@value": "A thing presented in support of the truthfulness of a claim."
-      }
-    ]
-  },
-  {
-    "@id": "http://w3id.org/claimont#Subject",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#comment": [
-      {
-        "@value": "Deprecated. Use owl:Thing instead."
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "Subject"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#deprecated": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-        "@value": true
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#equivalentClass": [
-      {
-        "@id": "http://www.w3.org/2002/07/owl#Thing"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@value": "The thing about which a statement (i.e., a claim or an attestation) is made."
-      }
-    ]
-  },
-  {
-    "@id": "http://w3id.org/claimont",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Ontology"
-    ],
-    "http://purl.org/dc/terms/description": [
-      {
-        "@language": "en",
-        "@value": "An ontology for describing claims and their substantiation."
-      }
-    ],
-    "http://purl.org/dc/terms/title": [
-      {
-        "@language": "en",
-        "@value": "Claim Ontology"
-      }
-    ]
-  },
-  {
-    "@id": "http://w3id.org/claimont#supports",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#ObjectProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#domain": [
-      {
-        "@id": "http://w3id.org/claimont#Substantiation"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "supports"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#range": [
-      {
-        "@id": "http://w3id.org/claimont#Claim"
+        "@id": "http://www.w3.org/2000/01/rdf-schema#Resource"
       }
     ],
     "http://www.w3.org/2002/07/owl#inverseOf": [
       {
-        "@id": "http://w3id.org/claimont#isSupportedBy"
+        "@id": "http://w3id.org/claimont#supports"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
       {
-        "@value": "Indicates that a substantiation provides evidence or backing for a particular claim."
-      }
-    ]
-  },
-  {
-    "@id": "http://w3id.org/claimont#comprisesClaims",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#ObjectProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#domain": [
-      {
-        "@id": "http://w3id.org/claimont#Claim"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "comprisesClaims"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#range": [
-      {
-        "@id": "http://w3id.org/claimont#Claim"
-      }
-    ]
-  },
-  {
-    "@id": "http://w3id.org/claimont#Claim",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#comment": [
-      {
-        "@value": "A Claim may comprise other Claims."
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "Claim"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
-      {
-        "@id": "http://docs.oasis-open.org/legalruleml/ns/v1.0/Statement"
-      },
-      {
-        "@id": "_:N1fa4dfc670a54721af50ac70160b6290"
-      },
-      {
-        "@id": "_:N06ff9ed8322a4aabb1f1b769c4074c08"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@value": "A defeasible statement about a thing."
-      }
-    ]
-  },
-  {
-    "@id": "_:N1fa4dfc670a54721af50ac70160b6290",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "http://www.w3.org/2002/07/owl#Thing"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "http://w3id.org/claimont#hasSubject"
-      }
-    ]
-  },
-  {
-    "@id": "_:N06ff9ed8322a4aabb1f1b769c4074c08",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "http://w3id.org/claimont#Claimant"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "http://w3id.org/claimont#isMadeBy"
-      }
-    ]
-  },
-  {
-    "@id": "_:Nbf93ee58f3a94a90aca282b1a92fa599",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#AllDisjointClasses"
-    ],
-    "http://www.w3.org/2002/07/owl#members": [
-      {
-        "@list": [
-          {
-            "@id": "http://w3id.org/claimont#Claim"
-          },
-          {
-            "@id": "http://w3id.org/claimont#Substantiation"
-          }
-        ]
+        "@value": "Indicates that the claim in question is backed or reinforced by the resource in question."
       }
     ]
   }

--- a/claimont.owl
+++ b/claimont.owl
@@ -23,7 +23,7 @@
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="http://w3id.org/claimont#hasSubject"/>
-				<owl:allValuesFrom rdf:resource="http://w3id.org/claimont#Subject"/>
+				<owl:allValuesFrom rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
@@ -43,16 +43,22 @@
 		<rdfs:label>Subject</rdfs:label>
 		<skos:definition>The thing about which a statement (i.e., a claim or an attestation) is made.</skos:definition>
 		<owl:equivalentClass rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+        <rdfs:comment>Deprecated. Use owl:Thing instead.</rdfs:comment>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>		
 	</owl:Class>
 	
 	<owl:Class rdf:about="http://w3id.org/claimont#Predicate">
 		<rdfs:label>Predicate</rdfs:label>
 		<skos:definition>The characteristic, attribute, or relationship asserted about the subject of a claim or an attestation.</skos:definition>
+        <rdfs:comment>Deprecated. Use owl:Thing instead.</rdfs:comment>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>		
 	</owl:Class>
 	
 	<owl:Class rdf:about="http://w3id.org/claimont#Object">
 		<rdfs:label>Object</rdfs:label>
 		<skos:definition>The target or value associated with the predicate of a claim or an attestation.</skos:definition>
+        <rdfs:comment>Deprecated. Use owl:Thing instead.</rdfs:comment>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>		
 	</owl:Class>
 	
 	<owl:Class rdf:about="http://w3id.org/claimont#Substantiation">
@@ -116,17 +122,43 @@
 		<rdfs:label>hasSubject</rdfs:label>
 		<rdfs:comment>This property is used on the Claim and Attestation classes. For a Claim the value assigned to this property must be a Subject; for an Attestation the value must be a Claim. This is enforced by owl:Restriction (see the definitions of the Claim and Attestation classes.)</rdfs:comment>
 	</owl:ObjectProperty>	
-
-	<owl:ObjectProperty rdf:about="http://w3id.org/claimont#hasPredicate">
-		<rdfs:label>hasPredicate</rdfs:label>
-		<rdfs:domain rdf:resource="#Claim"/>
-		<rdfs:range rdf:resource="#Predicate"/>
-	</owl:ObjectProperty>
+	
+	<rdf:Property rdf:about="http://w3id.org/claimont#hasPredicate">
+		<rdfs:label xml:lang="en">hasPredicate</rdfs:label>
+		<rdfs:domain>
+			<owl:Class>
+				<owl:unionOf rdf:parseType="Collection">
+					<rdf:Description rdf:about="http://w3id.org/claimont#Claim"/>
+					<rdf:Description rdf:about="http://w3id.org/claimont#Attestation"/>
+				</owl:unionOf>
+			</owl:Class>
+		</rdfs:domain>
+		<rdfs:comment xml:lang="en">Generic property that relates a claim or attestation to its predicate.</rdfs:comment>
+		<rdfs:comment xml:lang="en">Do not use this property directly - use its 'hasTextPredicate' or 'hasPropertyPredicate' subproperties instead.</rdfs:comment>
+	</rdf:Property>	
+	
+	<owl:DatatypeProperty rdf:about="http://w3id.org/claimont#hasTextPredicate">
+		<rdfs:label xml:lang="en">hasTextPredicate</rdfs:label>
+		<rdfs:subPropertyOf rdf:resource="http://w3id.org/claimont#hasPredicate"/>
+		<rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
+		<rdfs:comment xml:lang="en">
+			Relates a claim or attestation to its predicate through a simple text string.
+		</rdfs:comment>
+	</owl:DatatypeProperty>	
+	
+	<owl:ObjectProperty rdf:about="http://w3id.org/claimont#hasPropertyPredicate">
+		<rdfs:label xml:lang="en">hasPropertyPredicate</rdfs:label>
+		<rdfs:subPropertyOf rdf:resource="http://w3id.org/claimont#hasPredicate"/>
+		<rdfs:range rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+		<rdfs:comment xml:lang="en">
+			Relates a claim or attestation to the RDF, RDFS, OWL object property, or OWL data property that represents the predicate of the claim.
+		</rdfs:comment>
+	</owl:ObjectProperty>	
 	
 	<owl:ObjectProperty rdf:about="http://w3id.org/claimont#hasObject">
 		<rdfs:label>hasObject</rdfs:label>
 		<rdfs:domain rdf:resource="#Claim"/>
-		<rdfs:range rdf:resource="#Object"/>
+		<rdfs:range rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="http://w3id.org/claimont#comprisesClaims">
@@ -147,7 +179,7 @@
 		<rdfs:domain rdf:resource="#Substantiation"/>
 		<rdfs:range rdf:resource="#Claim"/>
 		<rdfs:label>supports</rdfs:label>
-		<skos:definition>Indicates that a substantiation provides evidence or backing for a particular claim.</skos:definition> 
+		<skos:definition>Indicates that a substantiation provides evidence or backing for a particular claim.</skos:definition>
 		<owl:inverseOf rdf:resource="#isSupportedBy"/>
 	</owl:ObjectProperty>	
 

--- a/claimont.owl
+++ b/claimont.owl
@@ -64,6 +64,8 @@
 	<owl:Class rdf:about="http://w3id.org/claimont#Substantiation">
 		<rdfs:label>Substantiation</rdfs:label>
 		<skos:definition>A thing presented in support of the truthfulness of a claim.</skos:definition>
+        <rdfs:comment>Deprecated.</rdfs:comment>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>			
 	</owl:Class>
 
 	<owl:Class rdf:about="http://w3id.org/claimont#IdentityClaim">
@@ -73,7 +75,6 @@
 	</owl:Class>
 
 	<owl:Class rdf:about="http://w3id.org/claimont#Attestation">
-		<rdfs:subClassOf rdf:resource="#Substantiation"/>
 		<rdfs:subClassOf rdf:resource="http://docs.oasis-open.org/legalruleml/ns/v1.0/Statement"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
@@ -102,14 +103,6 @@
 		<rdfs:label>Report</rdfs:label>
 		<skos:definition>A claim made according to some specification.</skos:definition>
 	</owl:Class>
-
-	<!-- Disjoint Classes -->
-	<owl:AllDisjointClasses>
-		<owl:members rdf:parseType="Collection">
-			<owl:Class rdf:about="#Claim"/>
-			<owl:Class rdf:about="#Substantiation"/>
-		</owl:members>
-	</owl:AllDisjointClasses>	
 
 	<!-- Properties -->
 
@@ -169,17 +162,17 @@
 	
 	<owl:ObjectProperty rdf:about="http://w3id.org/claimont#isSupportedBy">
 		<rdfs:domain rdf:resource="#Claim"/>
-		<rdfs:range rdf:resource="#Substantiation"/>
+		<rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
 		 <rdfs:label>isSupportedBy</rdfs:label>
-		<skos:definition>Indicates that a claim is backed or reinforced by some form of substantiation or evidence.</skos:definition>
+		<skos:definition>Indicates that the claim in question is backed or reinforced by the resource in question.</skos:definition>
 		<owl:inverseOf rdf:resource="#supports"/>		
 	</owl:ObjectProperty>
 
 	<owl:ObjectProperty rdf:about="http://w3id.org/claimont#supports">
-		<rdfs:domain rdf:resource="#Substantiation"/>
+		<rdfs:domain rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
 		<rdfs:range rdf:resource="#Claim"/>
 		<rdfs:label>supports</rdfs:label>
-		<skos:definition>Indicates that a substantiation provides evidence or backing for a particular claim.</skos:definition>
+		<skos:definition>Indicates that the resource in question serves as evidence or backing for the claim in question.</skos:definition>
 		<owl:inverseOf rdf:resource="#isSupportedBy"/>
 	</owl:ObjectProperty>	
 

--- a/claimont.ttl
+++ b/claimont.ttl
@@ -5,10 +5,66 @@
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 <http://w3id.org/claimont> a owl:Ontology ;
     dcterms:description "An ontology for describing claims and their substantiation."@en ;
     dcterms:title "Claim Ontology"@en .
+
+:IdentityClaim a owl:Class ;
+    rdfs:label "Identity Claim" ;
+    rdfs:subClassOf :Claim ;
+    skos:definition "A statement made by a claimant about their identity, usually with reference to some identification system." .
+
+:Object a owl:Class ;
+    rdfs:label "Object" ;
+    rdfs:comment "Deprecated. Use owl:Thing instead." ;
+    owl:deprecated true ;
+    skos:definition "The target or value associated with the predicate of a claim or an attestation." .
+
+:Predicate a owl:Class ;
+    rdfs:label "Predicate" ;
+    rdfs:comment "Deprecated. Use owl:Thing instead." ;
+    owl:deprecated true ;
+    skos:definition "The characteristic, attribute, or relationship asserted about the subject of a claim or an attestation." .
+
+:Report a owl:Class ;
+    rdfs:label "Report" ;
+    rdfs:subClassOf :Claim ;
+    skos:definition "A claim made according to some specification." .
+
+:Subject a owl:Class ;
+    rdfs:label "Subject" ;
+    rdfs:comment "Deprecated. Use owl:Thing instead." ;
+    owl:deprecated true ;
+    owl:equivalentClass owl:Thing ;
+    skos:definition "The thing about which a statement (i.e., a claim or an attestation) is made." .
+
+:comprisesClaims a owl:ObjectProperty ;
+    rdfs:label "comprisesClaims" ;
+    rdfs:domain :Claim ;
+    rdfs:range :Claim .
+
+:hasObject a owl:ObjectProperty ;
+    rdfs:label "hasObject" ;
+    rdfs:domain :Claim ;
+    rdfs:range owl:Thing .
+
+:hasPropertyPredicate a owl:ObjectProperty ;
+    rdfs:label "hasPropertyPredicate"@en ;
+    rdfs:comment """
+			Relates a claim or attestation to the RDF, RDFS, OWL object property, or OWL data property that represents the predicate of the claim.
+		"""@en ;
+    rdfs:range rdf:Property ;
+    rdfs:subPropertyOf :hasPredicate .
+
+:hasTextPredicate a owl:DatatypeProperty ;
+    rdfs:label "hasTextPredicate"@en ;
+    rdfs:comment """
+			Relates a claim or attestation to its predicate through a simple text string.
+		"""@en ;
+    rdfs:range xsd:string ;
+    rdfs:subPropertyOf :hasPredicate .
 
 :Attestation a owl:Class ;
     rdfs:label "Attestation" ;
@@ -23,31 +79,6 @@
         :Substantiation ;
     skos:definition "An indefeasible statement, usually formal, made by an entity according to which they have witnessed or been presented with sufficient evidence to consider a specific claim made by another entity as truthful or accurate." .
 
-:IdentityClaim a owl:Class ;
-    rdfs:label "Identity Claim" ;
-    rdfs:subClassOf :Claim ;
-    skos:definition "A statement made by a claimant about their identity, usually with reference to some identification system." .
-
-:Report a owl:Class ;
-    rdfs:label "Report" ;
-    rdfs:subClassOf :Claim ;
-    skos:definition "A claim made according to some specification." .
-
-:comprisesClaims a owl:ObjectProperty ;
-    rdfs:label "comprisesClaims" ;
-    rdfs:domain :Claim ;
-    rdfs:range :Claim .
-
-:hasObject a owl:ObjectProperty ;
-    rdfs:label "hasObject" ;
-    rdfs:domain :Claim ;
-    rdfs:range :Object .
-
-:hasPredicate a owl:ObjectProperty ;
-    rdfs:label "hasPredicate" ;
-    rdfs:domain :Claim ;
-    rdfs:range :Predicate .
-
 :Attester a owl:Class ;
     rdfs:label "Attester" ;
     skos:definition "An entity (e.g., a person, an organisation or a system) that makes an attestation." .
@@ -55,19 +86,6 @@
 :Claimant a owl:Class ;
     rdfs:label "Claimant" ;
     skos:definition "An entity (e.g., a person, an organisation or a system) that makes a claim." .
-
-:Object a owl:Class ;
-    rdfs:label "Object" ;
-    skos:definition "The target or value associated with the predicate of a claim or an attestation." .
-
-:Predicate a owl:Class ;
-    rdfs:label "Predicate" ;
-    skos:definition "The characteristic, attribute, or relationship asserted about the subject of a claim or an attestation." .
-
-:Subject a owl:Class ;
-    rdfs:label "Subject" ;
-    owl:equivalentClass owl:Thing ;
-    skos:definition "The thing about which a statement (i.e., a claim or an attestation) is made." .
 
 :isSupportedBy a owl:ObjectProperty ;
     rdfs:label "isSupportedBy" ;
@@ -82,6 +100,13 @@
     rdfs:range :Claim ;
     owl:inverseOf :isSupportedBy ;
     skos:definition "Indicates that a substantiation provides evidence or backing for a particular claim." .
+
+:hasPredicate a rdf:Property ;
+    rdfs:label "hasPredicate"@en ;
+    rdfs:comment "Do not use this property directly - use its 'hasTextPredicate' or 'hasPropertyPredicate' subproperties instead."@en,
+        "Generic property that relates a claim or attestation to its predicate."@en ;
+    rdfs:domain [ a owl:Class ;
+            owl:unionOf ( :Claim :Attestation ) ] .
 
 :hasSubject a owl:ObjectProperty ;
     rdfs:label "hasSubject" ;
@@ -102,7 +127,7 @@
             owl:allValuesFrom :Claimant ;
             owl:onProperty :isMadeBy ],
         [ a owl:Restriction ;
-            owl:allValuesFrom :Subject ;
+            owl:allValuesFrom owl:Thing ;
             owl:onProperty :hasSubject ],
         lrml:Statement ;
     skos:definition "A defeasible statement about a thing." .

--- a/claimont.ttl
+++ b/claimont.ttl
@@ -40,6 +40,12 @@
     owl:equivalentClass owl:Thing ;
     skos:definition "The thing about which a statement (i.e., a claim or an attestation) is made." .
 
+:Substantiation a owl:Class ;
+    rdfs:label "Substantiation" ;
+    rdfs:comment "Deprecated." ;
+    owl:deprecated true ;
+    skos:definition "A thing presented in support of the truthfulness of a claim." .
+
 :comprisesClaims a owl:ObjectProperty ;
     rdfs:label "comprisesClaims" ;
     rdfs:domain :Claim ;
@@ -70,13 +76,12 @@
     rdfs:label "Attestation" ;
     rdfs:comment "A verifier's statement is an example of an attestation." ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom :Attester ;
-            owl:onProperty :isMadeBy ],
-        [ a owl:Restriction ;
             owl:allValuesFrom :Claim ;
             owl:onProperty :hasSubject ],
-        lrml:Statement,
-        :Substantiation ;
+        [ a owl:Restriction ;
+            owl:allValuesFrom :Attester ;
+            owl:onProperty :isMadeBy ],
+        lrml:Statement ;
     skos:definition "An indefeasible statement, usually formal, made by an entity according to which they have witnessed or been presented with sufficient evidence to consider a specific claim made by another entity as truthful or accurate." .
 
 :Attester a owl:Class ;
@@ -90,16 +95,16 @@
 :isSupportedBy a owl:ObjectProperty ;
     rdfs:label "isSupportedBy" ;
     rdfs:domain :Claim ;
-    rdfs:range :Substantiation ;
+    rdfs:range rdfs:Resource ;
     owl:inverseOf :supports ;
-    skos:definition "Indicates that a claim is backed or reinforced by some form of substantiation or evidence." .
+    skos:definition "Indicates that the claim in question is backed or reinforced by the resource in question." .
 
 :supports a owl:ObjectProperty ;
     rdfs:label "supports" ;
-    rdfs:domain :Substantiation ;
+    rdfs:domain rdfs:Resource ;
     rdfs:range :Claim ;
     owl:inverseOf :isSupportedBy ;
-    skos:definition "Indicates that a substantiation provides evidence or backing for a particular claim." .
+    skos:definition "Indicates that the resource in question serves as evidence or backing for the claim in question." .
 
 :hasPredicate a rdf:Property ;
     rdfs:label "hasPredicate"@en ;
@@ -116,10 +121,6 @@
     rdfs:label "isMadeBy" ;
     rdfs:comment "This property is used on the Claim and Attestation classes. For a Claim the value assigned to this property must be a Claimant; for an Attestation the value must be an Attester. This is enforced by owl:Restriction (see the definitions of the Claim and Attestation classes.)" .
 
-:Substantiation a owl:Class ;
-    rdfs:label "Substantiation" ;
-    skos:definition "A thing presented in support of the truthfulness of a claim." .
-
 :Claim a owl:Class ;
     rdfs:label "Claim" ;
     rdfs:comment "A Claim may comprise other Claims." ;
@@ -131,7 +132,4 @@
             owl:onProperty :hasSubject ],
         lrml:Statement ;
     skos:definition "A defeasible statement about a thing." .
-
-[] a owl:AllDisjointClasses ;
-    owl:members ( :Claim :Substantiation ) .
 

--- a/docs/claimont.html
+++ b/docs/claimont.html
@@ -66,7 +66,7 @@
       <div class="kv">
           <div class="key">Classes</div>
           <div>
-              <a href="#cls-<N0a192c29a0e7405ea3570f00bc2ddd90>"><N0a192c29a0e7405ea3570f00bc2ddd90></a>,               <a href="#cls--Attestation">Attestation</a>,               <a href="#cls--Attester">Attester</a>,               <a href="#cls--Claim">Claim</a>,               <a href="#cls--Claimant">Claimant</a>,               <a href="#cls--IdentityClaim">Identity Claim</a>,               <a href="#cls--Object">Object</a>,               <a href="#cls--Predicate">Predicate</a>,               <a href="#cls--Report">Report</a>,               <a href="#cls--Subject">Subject</a>,               <a href="#cls--Substantiation">Substantiation</a>          </div>
+              <a href="#cls-<N63bfdf57e9be4bfd98a5893aedc244cf>"><N63bfdf57e9be4bfd98a5893aedc244cf></a>,               <a href="#cls--Attestation">Attestation</a>,               <a href="#cls--Attester">Attester</a>,               <a href="#cls--Claim">Claim</a>,               <a href="#cls--Claimant">Claimant</a>,               <a href="#cls--IdentityClaim">Identity Claim</a>,               <a href="#cls--Object">Object</a>,               <a href="#cls--Predicate">Predicate</a>,               <a href="#cls--Report">Report</a>,               <a href="#cls--Subject">Subject</a>,               <a href="#cls--Substantiation">Substantiation</a>          </div>
           <div class="key">Properties</div>
           <div>
               <a href="#prop--comprisesClaims">comprisesClaims</a>,               <a href="#prop--hasObject">hasObject</a>,               <a href="#prop--hasPredicate">hasPredicate</a>,               <a href="#prop--hasPropertyPredicate">hasPropertyPredicate</a>,               <a href="#prop--hasSubject">hasSubject</a>,               <a href="#prop--hasTextPredicate">hasTextPredicate</a>,               <a href="#prop--isMadeBy">isMadeBy</a>,               <a href="#prop--isSupportedBy">isSupportedBy</a>,               <a href="#prop--supports">supports</a>          </div>
@@ -76,9 +76,9 @@
     <div class="grid">
       <section>
         <h2>Classes</h2>
-          <div class="item" id="cls-<N0a192c29a0e7405ea3570f00bc2ddd90>">
-            <h3><N0a192c29a0e7405ea3570f00bc2ddd90></h3>
-            <div class="meta">IRI: <code>N0a192c29a0e7405ea3570f00bc2ddd90</code></div>
+          <div class="item" id="cls-<N63bfdf57e9be4bfd98a5893aedc244cf>">
+            <h3><N63bfdf57e9be4bfd98a5893aedc244cf></h3>
+            <div class="meta">IRI: <code>N63bfdf57e9be4bfd98a5893aedc244cf</code></div>
 
 
 
@@ -98,7 +98,7 @@
             <div class="kv">
                 <div class="key">SubClass Of</div>
                 <div>
-                    <a href="#cls--Substantiation">:Substantiation</a>,                     <a href="http://docs.oasis-open.org/legalruleml/ns/v1.0/Statement">lrml:Statement</a>                </div>
+                    <a href="http://docs.oasis-open.org/legalruleml/ns/v1.0/Statement">lrml:Statement</a>                </div>
             </div>
           </div>
           <div class="item" id="cls--Attester">
@@ -222,17 +222,10 @@
               <div class="section-title"><span class="badge">SKOS</span>Definition</div>
                 <div class="defblock">A thing presented in support of the truthfulness of a claim.</div>
 
+              <div class="section-title">Comments</div>
+                <div class="comment">Deprecated.</div>
 
             <div class="kv">
-                <div class="key">Superclass Of</div>
-                <div>
-                    <a href="#cls--Attestation">:Attestation</a>                </div>
-                <div class="key">In Domain Of</div>
-                <div>
-                    <a href="#prop--supports">:supports</a>                </div>
-                <div class="key">In Range Of</div>
-                <div>
-                    <a href="#prop--isSupportedBy">:isSupportedBy</a>                </div>
             </div>
           </div>
       </section>
@@ -346,7 +339,7 @@
             <div class="meta">IRI: <code>http://w3id.org/claimont#isSupportedBy</code></div>
 
               <div class="section-title"><span class="badge">SKOS</span>Definition</div>
-                <div class="defblock">Indicates that a claim is backed or reinforced by some form of substantiation or evidence.</div>
+                <div class="defblock">Indicates that the claim in question is backed or reinforced by the resource in question.</div>
 
 
             <div class="kv">
@@ -355,7 +348,7 @@
                     <a href="#cls--Claim">:Claim</a>                </div>
                 <div class="key">Range</div>
                 <div>
-                    <a href="#cls--Substantiation">:Substantiation</a>                </div>
+                    <a href="#cls-rdfs-Resource">rdfs:Resource</a>                </div>
                 <div class="key">Inverse Of</div>
                 <div>
                     <a href="#prop--supports">:supports</a>                </div>
@@ -366,13 +359,13 @@
             <div class="meta">IRI: <code>http://w3id.org/claimont#supports</code></div>
 
               <div class="section-title"><span class="badge">SKOS</span>Definition</div>
-                <div class="defblock">Indicates that a substantiation provides evidence or backing for a particular claim.</div>
+                <div class="defblock">Indicates that the resource in question serves as evidence or backing for the claim in question.</div>
 
 
             <div class="kv">
                 <div class="key">Domain</div>
                 <div>
-                    <a href="#cls--Substantiation">:Substantiation</a>                </div>
+                    <a href="#cls-rdfs-Resource">rdfs:Resource</a>                </div>
                 <div class="key">Range</div>
                 <div>
                     <a href="#cls--Claim">:Claim</a>                </div>

--- a/docs/claimont.html
+++ b/docs/claimont.html
@@ -57,6 +57,7 @@
           <code>rdf: &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#&gt;</code><br />
           <code>rdfs: &lt;http://www.w3.org/2000/01/rdf-schema#&gt;</code><br />
           <code>skos: &lt;http://www.w3.org/2004/02/skos/core#&gt;</code><br />
+          <code>xsd: &lt;http://www.w3.org/2001/XMLSchema#&gt;</code><br />
       </div>
     </header>
 
@@ -65,16 +66,25 @@
       <div class="kv">
           <div class="key">Classes</div>
           <div>
-              <a href="#cls--Attestation">Attestation</a>,               <a href="#cls--Attester">Attester</a>,               <a href="#cls--Claim">Claim</a>,               <a href="#cls--Claimant">Claimant</a>,               <a href="#cls--IdentityClaim">Identity Claim</a>,               <a href="#cls--Object">Object</a>,               <a href="#cls--Predicate">Predicate</a>,               <a href="#cls--Report">Report</a>,               <a href="#cls--Subject">Subject</a>,               <a href="#cls--Substantiation">Substantiation</a>          </div>
+              <a href="#cls-<N0a192c29a0e7405ea3570f00bc2ddd90>"><N0a192c29a0e7405ea3570f00bc2ddd90></a>,               <a href="#cls--Attestation">Attestation</a>,               <a href="#cls--Attester">Attester</a>,               <a href="#cls--Claim">Claim</a>,               <a href="#cls--Claimant">Claimant</a>,               <a href="#cls--IdentityClaim">Identity Claim</a>,               <a href="#cls--Object">Object</a>,               <a href="#cls--Predicate">Predicate</a>,               <a href="#cls--Report">Report</a>,               <a href="#cls--Subject">Subject</a>,               <a href="#cls--Substantiation">Substantiation</a>          </div>
           <div class="key">Properties</div>
           <div>
-              <a href="#prop--comprisesClaims">comprisesClaims</a>,               <a href="#prop--hasObject">hasObject</a>,               <a href="#prop--hasPredicate">hasPredicate</a>,               <a href="#prop--hasSubject">hasSubject</a>,               <a href="#prop--isMadeBy">isMadeBy</a>,               <a href="#prop--isSupportedBy">isSupportedBy</a>,               <a href="#prop--supports">supports</a>          </div>
+              <a href="#prop--comprisesClaims">comprisesClaims</a>,               <a href="#prop--hasObject">hasObject</a>,               <a href="#prop--hasPredicate">hasPredicate</a>,               <a href="#prop--hasPropertyPredicate">hasPropertyPredicate</a>,               <a href="#prop--hasSubject">hasSubject</a>,               <a href="#prop--hasTextPredicate">hasTextPredicate</a>,               <a href="#prop--isMadeBy">isMadeBy</a>,               <a href="#prop--isSupportedBy">isSupportedBy</a>,               <a href="#prop--supports">supports</a>          </div>
       </div>
     </section>
 
     <div class="grid">
       <section>
         <h2>Classes</h2>
+          <div class="item" id="cls-<N0a192c29a0e7405ea3570f00bc2ddd90>">
+            <h3><N0a192c29a0e7405ea3570f00bc2ddd90></h3>
+            <div class="meta">IRI: <code>N0a192c29a0e7405ea3570f00bc2ddd90</code></div>
+
+
+
+            <div class="kv">
+            </div>
+          </div>
           <div class="item" id="cls--Attestation">
             <h3>Attestation</h3>
             <div class="meta">IRI: <code>http://w3id.org/claimont#Attestation</code></div>
@@ -121,7 +131,7 @@
                     <a href="#cls--IdentityClaim">:IdentityClaim</a>,                     <a href="#cls--Report">:Report</a>                </div>
                 <div class="key">In Domain Of</div>
                 <div>
-                    <a href="#prop--hasPredicate">:hasPredicate</a>,                     <a href="#prop--hasObject">:hasObject</a>,                     <a href="#prop--comprisesClaims">:comprisesClaims</a>,                     <a href="#prop--isSupportedBy">:isSupportedBy</a>                </div>
+                    <a href="#prop--hasObject">:hasObject</a>,                     <a href="#prop--comprisesClaims">:comprisesClaims</a>,                     <a href="#prop--isSupportedBy">:isSupportedBy</a>                </div>
                 <div class="key">In Range Of</div>
                 <div>
                     <a href="#prop--comprisesClaims">:comprisesClaims</a>,                     <a href="#prop--supports">:supports</a>                </div>
@@ -159,11 +169,10 @@
               <div class="section-title"><span class="badge">SKOS</span>Definition</div>
                 <div class="defblock">The target or value associated with the predicate of a claim or an attestation.</div>
 
+              <div class="section-title">Comments</div>
+                <div class="comment">Deprecated. Use owl:Thing instead.</div>
 
             <div class="kv">
-                <div class="key">In Range Of</div>
-                <div>
-                    <a href="#prop--hasObject">:hasObject</a>                </div>
             </div>
           </div>
           <div class="item" id="cls--Predicate">
@@ -173,11 +182,10 @@
               <div class="section-title"><span class="badge">SKOS</span>Definition</div>
                 <div class="defblock">The characteristic, attribute, or relationship asserted about the subject of a claim or an attestation.</div>
 
+              <div class="section-title">Comments</div>
+                <div class="comment">Deprecated. Use owl:Thing instead.</div>
 
             <div class="kv">
-                <div class="key">In Range Of</div>
-                <div>
-                    <a href="#prop--hasPredicate">:hasPredicate</a>                </div>
             </div>
           </div>
           <div class="item" id="cls--Report">
@@ -201,6 +209,8 @@
               <div class="section-title"><span class="badge">SKOS</span>Definition</div>
                 <div class="defblock">The thing about which a statement (i.e., a claim or an attestation) is made.</div>
 
+              <div class="section-title">Comments</div>
+                <div class="comment">Deprecated. Use owl:Thing instead.</div>
 
             <div class="kv">
             </div>
@@ -256,7 +266,7 @@
                     <a href="#cls--Claim">:Claim</a>                </div>
                 <div class="key">Range</div>
                 <div>
-                    <a href="#cls--Object">:Object</a>                </div>
+                    <a href="#cls-owl-Thing">owl:Thing</a>                </div>
             </div>
           </div>
           <div class="item" id="prop--hasPredicate">
@@ -264,14 +274,30 @@
             <div class="meta">IRI: <code>http://w3id.org/claimont#hasPredicate</code></div>
 
 
+              <div class="section-title">Comments</div>
+                <div class="comment">Generic property that relates a claim or attestation to its predicate.</div>
+                <div class="comment">Do not use this property directly - use its 'hasTextPredicate' or 'hasPropertyPredicate' subproperties instead.</div>
 
             <div class="kv">
-                <div class="key">Domain</div>
-                <div>
-                    <a href="#cls--Claim">:Claim</a>                </div>
+            </div>
+          </div>
+          <div class="item" id="prop--hasPropertyPredicate">
+            <h3>hasPropertyPredicate</h3>
+            <div class="meta">IRI: <code>http://w3id.org/claimont#hasPropertyPredicate</code></div>
+
+
+              <div class="section-title">Comments</div>
+                <div class="comment">
+			Relates a claim or attestation to the RDF, RDFS, OWL object property, or OWL data property that represents the predicate of the claim.
+		</div>
+
+            <div class="kv">
                 <div class="key">Range</div>
                 <div>
-                    <a href="#cls--Predicate">:Predicate</a>                </div>
+                    <a href="#cls-rdf-Property">rdf:Property</a>                </div>
+                <div class="key">SubProperty Of</div>
+                <div>
+                    <a href="#prop--hasPredicate">:hasPredicate</a>                </div>
             </div>
           </div>
           <div class="item" id="prop--hasSubject">
@@ -283,6 +309,25 @@
                 <div class="comment">This property is used on the Claim and Attestation classes. For a Claim the value assigned to this property must be a Subject; for an Attestation the value must be a Claim. This is enforced by owl:Restriction (see the definitions of the Claim and Attestation classes.)</div>
 
             <div class="kv">
+            </div>
+          </div>
+          <div class="item" id="prop--hasTextPredicate">
+            <h3>hasTextPredicate</h3>
+            <div class="meta">IRI: <code>http://w3id.org/claimont#hasTextPredicate</code></div>
+
+
+              <div class="section-title">Comments</div>
+                <div class="comment">
+			Relates a claim or attestation to its predicate through a simple text string.
+		</div>
+
+            <div class="kv">
+                <div class="key">Range</div>
+                <div>
+                    <a href="#cls-xsd-string">xsd:string</a>                </div>
+                <div class="key">SubProperty Of</div>
+                <div>
+                    <a href="#prop--hasPredicate">:hasPredicate</a>                </div>
             </div>
           </div>
           <div class="item" id="prop--isMadeBy">


### PR DESCRIPTION
1. Changes `claimont:hasPredicate` from an `owl:ObjectProperty` to a generic `rdf:Property`.
2. Defines two new subclasses of `claimont:hasPredicate`, namely `claimont:hasTextPredicate` (datatype property) and `claimont:hasPropertyPredicate` (object property).
3. Deprecates classes `claimont:Subject`, `claimont:Predicate` and `claimont:Object`.
4. Redefines the range of `claimont:hasSubject` from `claimont:Subject` to `owl:Thing`.
5. Redefines the range of `claimont:hasObject` from `claimont:Object` to `owl:Thing`.
6. Deprecates the `claimont:Substantiation` class in favour of `rdfs:Resource`. Issue https://github.com/Semantic-Frameworks/claimont/issues/18.

Reason: Subjects, predicates and objects do not exist independently - any `owl:Thing` can be the subject or the object of a claim or attestation, and predicates can be either simple text strings or the IRIs of other, properly defined properties.